### PR TITLE
fix(pubspec): downgrade retrofit_generator

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   json_serializable: ^6.2.0
-  retrofit_generator: ^4.0.1
+  retrofit_generator: ^3.0.1
   surf_lint_rules: ^1.5.0
 
 environment:


### PR DESCRIPTION
Failure:
flutter_template depends on both flutter_test from sdk and retrofit_generator ^4.0.0, version solving failed.