### PR TITLE
fix: Add flutter_template pattern where necessary

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -36,7 +36,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "ru.surfstudio.flutterTemplate"
+        applicationId "dev.surf.flutter_template"
         minSdkVersion 21
         targetSdkVersion 32
         versionCode flutterVersionCode.toInteger()

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -10,7 +10,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:408916197886:android:cb9a7fce044b7a857240af",
         "android_client_info": {
-          "package_name": "ru.surfstudio.flutterTemplate.dev"
+          "package_name": "dev.surf.flutter_template.dev"
         }
       },
       "oauth_client": [

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.flutter_template">
+    package="dev.surf.flutter_template">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.flutter_template">
+    package="dev.surf.flutter_template">
 
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.

--- a/android/app/src/main/kotlin/com/example/flutter_template/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/flutter_template/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.flutter_template
+package dev.surf.flutter_template
 
 import io.flutter.embedding.android.FlutterActivity;
 

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.flutter_template">
+    package="dev.surf.flutter_template">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/ios/Flutter/common.xcconfig
+++ b/ios/Flutter/common.xcconfig
@@ -1,1 +1,1 @@
-identifier=ru.surfstudio.flutterTemplate
+identifier=dev.surf.flutter_template

--- a/ios/Runner/Firebase/prod/GoogleService-Info.plist
+++ b/ios/Runner/Firebase/prod/GoogleService-Info.plist
@@ -13,7 +13,7 @@
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
-	<string>ru.surfstudio.flutterTemplate</string>
+	<string>dev.surf.flutter_template</string>
 	<key>PROJECT_ID</key>
 	<string>flutter-template-prod</string>
 	<key>STORAGE_BUCKET</key>


### PR DESCRIPTION
1. There is a guide says "Search for flutter_template and replace it"
2. It's hard to find all the cases because of  `ru.surfstudio.flutterTemplate` pattern using

I fixed the problem with replacing to pattern dev.surf.flutter_template everywhere in the project.