### PR TITLE
feat: Add Surf packages to pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,9 @@ description: a Flutter template project for development.
 publish_to: none
 
 dependencies:
+  analytics: 1.0.2
   auto_route: 5.0.1
+  bottom_sheet: 3.1.2 
   dio: 4.0.6
   elementary: 1.5.0
   firebase_crashlytics: 2.8.10
@@ -14,6 +16,8 @@ dependencies:
     sdk: flutter
   logger: 1.1.0
   provider: 6.0.3
+  push_notification: 1.1.1
+  render_metrics: 2.0.2
   retrofit: 3.0.1+1
   shared_preferences: 2.0.15
   surf_logger: 1.1.0


### PR DESCRIPTION
This pull request add packages that were created inside Surf and are used universally on our projects.

Adding them to the template:
- We will make sure that in new projects we will not come up with "new" solutions, that lead us create a local equivalent in the project. 
- For a new developer who might not be familiar with the packages, it will be enough to type the keywords and the side will show the classes from the package.
- This will increase packages usage, and thereby bring more feedback for their further development.